### PR TITLE
Update Dockerfile to work with Go 1.16 Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.16-rc-alpine as builder
 RUN mkdir /build 
 ADD . /build/
 WORKDIR /build 


### PR DESCRIPTION
I tried to run this today, and it looks like the required go version hasn't made it to a point where the docker image label points to it. This had broken Docker image.
Got this error:
```
package embed is not in GOROOT (/usr/local/go/src/embed)
```
This is probably a super temporary fix, and may just be ok to leave this PR open in case anyone else looks at why this is not building for them.
